### PR TITLE
ynh_exec_warn_less

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -152,7 +152,7 @@ chown -R $app: $final_path
 update-alternatives --set php /usr/bin/php$phpversion
 
 pushd "$final_path"
-	sudo -u $app env PATH=$PATH drush site:install $install_profil --account-name=$admin --account-pass=$password --account-mail=$admin_mail --db-url=mysql://$db_user:$db_pwd@localhost/$db_name --site-name="$app" --locale=$language --yes
+	ynh_exec_warn_less sudo -u $app env PATH=$PATH drush site:install $install_profil --account-name=$admin --account-pass=$password --account-mail=$admin_mail --db-url=mysql://$db_user:$db_pwd@localhost/$db_name --site-name="$app" --locale=$language --yes
 popd
 
 update-alternatives --set php /usr/bin/php${YNH_DEFAULT_PHP_VERSION}

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -121,12 +121,12 @@ ynh_backup_if_checksum_is_different --file="$final_path/$app/sites/default/setti
 update-alternatives --set php /usr/bin/php$phpversion
 
 pushd "$final_path"
-    sudo -u $app env PATH=$PATH drush @$app.prod state:set system.maintenance_mode 1 --input-format=integer
-    sudo -u $app env PATH=$PATH php composer.phar update drupal/core webflo/drupal-core-require-dev --with-dependencies
-    sudo -u $app env PATH=$PATH php composer.phar update --with-dependencies
-    sudo -u $app env PATH=$PATH drush @$app.prod -y updatedb
-    sudo -u $app env PATH=$PATH drush @$app.prod cache:rebuild
-    sudo -u $app env PATH=$PATH drush @$app.prod state:set system.maintenance_mode 0 --input-format=integer
+    ynh_exec_warn_less sudo -u $app env PATH=$PATH drush @$app.prod state:set system.maintenance_mode 1 --input-format=integer
+    ynh_exec_warn_less sudo -u $app env PATH=$PATH php composer.phar update drupal/core webflo/drupal-core-require-dev --with-dependencies
+    ynh_exec_warn_less sudo -u $app env PATH=$PATH php composer.phar update --with-dependencies
+    ynh_exec_warn_less sudo -u $app env PATH=$PATH drush @$app.prod -y updatedb
+    ynh_exec_warn_less sudo -u $app env PATH=$PATH drush @$app.prod cache:rebuild
+    ynh_exec_warn_less sudo -u $app env PATH=$PATH drush @$app.prod state:set system.maintenance_mode 0 --input-format=integer
 popd
 
 update-alternatives --set php /usr/bin/php${YNH_DEFAULT_PHP_VERSION}


### PR DESCRIPTION
## Problem
- *Error: There's a shitload of warnings in the output ! If those warnings are coming from some app build step and ain't actual warnings, please redirect them to the standard output instead of the error output ...!*

## Solution
- *ynh_exec_warn_less*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
