### PR TITLE
Upgrade to php8.4 as recommended by Drupal

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Drupal"
 description.en = "Content management framework"
 description.fr = "Système de gestion de contenu"
 
-version = "2024.12.19~ynh1"
+version = "2024.12.19~ynh2"
 
 maintainers = ["yalh76"]
 
@@ -76,19 +76,19 @@ ram.runtime = "50M"
 
     [resources.apt]
     packages = [
-        "php8.3-fpm",
-        "php8.3-cli",
-        "php8.3-gd",
-        "php8.3-mysql",
-        "php8.3-xml",
-        "php8.3-ldap",
-        "php8.3-mbstring",
-        "php8.3-uploadprogress",
-        "php8.3-apcu",
-        "php8.3-json",
-        "php8.3-simplexml",
-        "php8.3-curl",
-        "php8.3-readline",
+        "php8.4-fpm",
+        "php8.4-cli",
+        "php8.4-gd",
+        "php8.4-mysql",
+        "php8.4-xml",
+        "php8.4-ldap",
+        "php8.4-mbstring",
+        "php8.4-uploadprogress",
+        "php8.4-apcu",
+        "php8.4-json",
+        "php8.4-simplexml",
+        "php8.4-curl",
+        "php8.4-readline",
         "curl",
         "libzip-dev",
         "mariadb-server",


### PR DESCRIPTION
## Problem

- For optimal performance Drupal recommends to use php8.4 

## Solution

- Update manifest to use php8.4 packages 

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
